### PR TITLE
Fix non-parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+on:
+  - push
+  - pull_request
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        version:
+          - '1.5'
+        os:
+          - ubuntu-latest
+          - macOS-latest
+          - windows-latest
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest
+  

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DataLoaders"
 uuid = "2e981812-ef13-4a9c-bfa0-ab13047b12a9"
 authors = ["lorenzoh <lorenz.ohly@gmail.com>"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/docs/simpleexample.jl
+++ b/docs/simpleexample.jl
@@ -13,7 +13,12 @@ for (xs, ys) in dataloader  # size(xs) == (128, 16)
     ## optimization step
 end
 
-
+# !!! note "Threading"
+#
+#     If you want to benefit from parallel data loading, start Julia with multiple threads
+#     by setting the `-t n` flag on startup.
+#
+#
 # `DataLoaders` supports many different data containers by building off the interface of
 # [`MLDataPattern.jl`](https://mldatautilsjl.readthedocs.io/en/latest/data/pattern.html).
 # Above, we pass in a tuple of datasets, hence the batch is also tuple.

--- a/src/DataLoaders.jl
+++ b/src/DataLoaders.jl
@@ -61,7 +61,7 @@ function DataLoader(
     )
 
     Threads.nthreads() > 1 || useprimary || error(
-        "Julia is running with on thread only, either pass `useprimary = true` or "
+        "Julia is running with on thread only, either pass `useprimary = true` or " *
         "start Julia with multiple threads by passing " *
         "the `-t n` option or setting the `JULIA_NUM_THREADS` " *
         "environment variable before starting Julia.")

--- a/src/DataLoaders.jl
+++ b/src/DataLoaders.jl
@@ -61,10 +61,10 @@ function DataLoader(
     )
 
     Threads.nthreads() > 1 || useprimary || error(
-        "Please start Julia with multiple threads by passing " *
+        "Julia is running with on thread only, either pass `useprimary = true` or "
+        "start Julia with multiple threads by passing " *
         "the `-t n` option or setting the `JULIA_NUM_THREADS` " *
-        "environment variable before starting Julia. If you don't " *
-        "want a parallel data loader, use `Flux.Data.DataLoader` for now.")
+        "environment variable before starting Julia.")
 
     batchwrapper = if isnothing(batchsize)
         identity

--- a/src/DataLoaders.jl
+++ b/src/DataLoaders.jl
@@ -61,7 +61,7 @@ function DataLoader(
     )
 
     Threads.nthreads() > 1 || useprimary || error(
-        "Julia is running with on thread only, either pass `useprimary = true` or " *
+        "Julia is running with one thread only, either pass `useprimary = true` or " *
         "start Julia with multiple threads by passing " *
         "the `-t n` option or setting the `JULIA_NUM_THREADS` " *
         "environment variable before starting Julia.")

--- a/src/batchview.jl
+++ b/src/batchview.jl
@@ -9,13 +9,15 @@ struct BatchDimLast <: BatchDim end
 A batch view of container `data` with collated batches of
 size `size`.
 """
-@with_kw struct BatchViewCollated{TData}
+@with_kw_noshow struct BatchViewCollated{TData}
     data::TData
     size::Int
     count::Int
     partial::Bool
     batchdim::BatchDim = BatchDimLast()
 end
+
+Base.show(io::IO, bvcollated::BatchViewCollated) = print(io, "batchviewcollated() with $(bvcollated.count) batches of size $(bvcollated.size)")
 
 const batchviewcollated = BatchViewCollated
 

--- a/src/loaders.jl
+++ b/src/loaders.jl
@@ -55,6 +55,8 @@ struct BufferGetObsParallel{TElem,TData}
     useprimary::Bool
 end
 
+Base.show(io::IO, bufparallel::BufferGetObsParallel) = print(io, "eachobsparallel($(bufparallel.data))")
+
 function BufferGetObsParallel(data; useprimary = false)
     nthreads = Threads.nthreads() - Int(!useprimary)
     nthreads > 0 ||
@@ -125,3 +127,6 @@ See also `MLDataPattern.eachobs`
 eachobsparallel(data; useprimary = false, buffered = true) =
     buffered ? BufferGetObsParallel(data, useprimary = useprimary) :
     GetObsParallel(data, useprimary = useprimary)
+
+
+eachobssequential(data) = ()

--- a/src/loaders.jl
+++ b/src/loaders.jl
@@ -127,6 +127,3 @@ See also `MLDataPattern.eachobs`
 eachobsparallel(data; useprimary = false, buffered = true) =
     buffered ? BufferGetObsParallel(data, useprimary = useprimary) :
     GetObsParallel(data, useprimary = useprimary)
-
-
-eachobssequential(data) = ()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -131,7 +131,7 @@ end
 
 
 @testset ExtendedTestSet "eachobsparallel unbuffered" begin
-    make() = eachobsparallel(rand(10, 64), buffered = false)
+    make() = eachobsparallel(rand(10, 64), buffered = false, useprimary = true)
 
     @testset ExtendedTestSet "iterate" begin
         dl = make()
@@ -144,7 +144,7 @@ end
 
 
 @testset ExtendedTestSet "eachobsparallel buffered" begin
-    make() = eachobsparallel(rand(10, 64), buffered = true)
+    make() = eachobsparallel(rand(10, 64), buffered = true, useprimary = true)
 
     @testset ExtendedTestSet "iterate" begin
         dl = make()
@@ -195,12 +195,12 @@ end
     end
 
     @testset ExtendedTestSet "collate" begin
-        dl = DataLoader(data, bs, buffered = false, parallel = false)
+        dl = DataLoader(data, bs, buffered = false)
         @test_nowarn for batch in dl end
     end
 
     @testset ExtendedTestSet "buffer, collate" begin
-        dl = DataLoader(data, bs, buffered = true, parallel = false)
+        dl = DataLoader(data, bs, buffered = true)
         @test_nowarn for batch in dl end
     end
 end


### PR DESCRIPTION
This fixes #12 by making it possible to create DataLoaders without having started Julia with multiple threads. The data loading is then performed on the main thread. It is still encouraged to start Julia with multiple threads to benefit from the paralllelism.