### PR TITLE
Increase LearnBase compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ ThreadPools = "b189fb0b-2eb5-4ed4-bc0c-d34c51242431"
 
 [compat]
 DocStringExtensions = "0.8"
-LearnBase = "0.3"
+LearnBase = "0.3, 0.4"
 MLDataPattern = "0.5"
 Parameters = "0.12"
 ThreadPools = "1.1"


### PR DESCRIPTION
Increase the LearnBase compat to 0.4 (last version before some more breaking changes which we will want to hold off on).